### PR TITLE
chore: build extensions before test-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Benchmarks
 
 ### Build / CI
+- Ensure `test-all` depends on `build` so extensions are current before running tests.
 
 ## 1.0.0b8 (Unreleased)
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test-py: ## Run tests
 test-c: ## Run C unit tests
 	$(MAKE) -C tests/orderbook/advanced/c test
 
-test-all: ## Run all tests (C + Python)
+test-all: build ## Run all tests (C + Python)
 	$(MAKE) test-c test-py
 
 test-coverage: ## Run tests with Cython-aware coverage (rebuild, test, clean)


### PR DESCRIPTION
Ensures the `test-all` Makefile target depends on `build` so native extensions are rebuilt before running the full test suite.